### PR TITLE
Fix namespace typo in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "autoload": {
     "psr-4": {
-      "OpsWay\\": "src/"
+      "Opsway\\": "src/"
     }
   },
   "extra": {


### PR DESCRIPTION
The namespace defined across the project is Opsway, but in composer is used OpsWay. It looks like unintentional typo and also prevents the classes to be properly loaded.