### PR TITLE
Fixed array type

### DIFF
--- a/src/Doctrine/DBAL/Types/ArrayBigInt.php
+++ b/src/Doctrine/DBAL/Types/ArrayBigInt.php
@@ -2,7 +2,22 @@
 
 namespace Opsway\Doctrine\DBAL\Types;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 class ArrayBigInt extends ArrayInt
 {
-    const ARRAY_INT = 'bigint[]';
+    public function getName()
+    {
+        return 'array_big_int';
+    }
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return '_int8';
+    }
+
+    public function getMappedDatabaseTypes(AbstractPlatform $platform)
+    {
+        return array('_int8');
+    }
 }

--- a/src/Doctrine/DBAL/Types/ArrayInt.php
+++ b/src/Doctrine/DBAL/Types/ArrayInt.php
@@ -7,16 +7,19 @@ use Doctrine\DBAL\Types\Type;
 
 class ArrayInt extends Type
 {
-    const ARRAY_INT = 'integer[]';
-
     public function getName()
     {
-        return static::ARRAY_INT;
+        return 'array_int';
     }
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return $platform->getDoctrineTypeMapping(static::ARRAY_INT);
+        return '_int4';
+    }
+
+    public function getMappedDatabaseTypes(AbstractPlatform $platform)
+    {
+        return array('_int4');
     }
 
     public function convertToDatabaseValue($array, AbstractPlatform $platform)


### PR DESCRIPTION
Hello.

It looks like you built *IntArray by inversing definition for doctrine
and definition in postgres layer.

I also added support for building the schema from the database by implementing
`getMappedDatabaseTypes` method.

As reference, you can see in [this repository](https://github.com/opensoft/doctrine-postgres-types/blob/master/src/Doctrine/DBAL/PostgresTypes/IntArrayType.php) a working implementation.

**Warning**: This is a major BC break. And I did not look at https://github.com/opsway/doctrine-dbal-postgresql/blob/master/src/Doctrine/DBAL/Types/TsVector.php, but it could be wrong too.

Finally, this repository on the one liked above have lots of feature
in common. It could be nice to merge theses repository together. ping @richardfullmer