### PR TITLE
Update deprecated code in jsonb example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Setting the column type to ```jsonb```.
 /**
  * @var array
  *
- * @ORM\Column(type="json_array", options={"jsonb=true"})
+ * @ORM\Column(type="json", nullable=true, options={"jsonb": true})
  */
 private $metaData;
 ```


### PR DESCRIPTION
json_array is deprecated since 2.6, you should use json instead. https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/types.html#json-array

The jsonb option was also updated to {"key": value} syntax and the column was made nullable as a best practice for storing "empty" JSON data.