### PR TITLE
Support GIN jsonb_ops indexes by 'gin_jsonb' flag

### DIFF
--- a/src/Doctrine/PostgreSQLPlatformDecorator.php
+++ b/src/Doctrine/PostgreSQLPlatformDecorator.php
@@ -29,6 +29,13 @@ class PostgreSQLPlatformDecorator extends PostgreSQL100Platform
                         },
                         $columnsOrIndex->getQuotedColumns($this)
                     ));
+                case $columnsOrIndex->hasFlag('gin_jsonb'):
+                    return implode(', ', array_map(
+                        static function ($column) {
+                            return sprintf('%s jsonb_ops', $column);
+                        },
+                        $columnsOrIndex->getQuotedColumns($this)
+                    ));
                 case $columnsOrIndex->hasFlag('gin_jsonb_path'):
                     return implode(', ', array_map(
                         static function ($column) {
@@ -62,6 +69,7 @@ class PostgreSQLPlatformDecorator extends PostgreSQL100Platform
             case $index->hasFlag('gist_intbig'):
                 $table = sprintf('%s USING GIST', $tableName);
                 break;
+            case $index->hasFlag('gin_jsonb'):
             case $index->hasFlag('gin_jsonb_path'):
             case $index->hasFlag('gin_trgm_ops'):
                 $table = sprintf('%s USING GIN', $tableName);

--- a/tests/Unit/PostgreSQLPlatformDecoratorTest.php
+++ b/tests/Unit/PostgreSQLPlatformDecoratorTest.php
@@ -67,6 +67,18 @@ class PostgreSQLPlatformDecoratorTest extends TestCase
             'table_name',
         ];
 
+        yield 'Check gin_jsonb flag' => [
+            'CREATE INDEX index_name ON table_name USING GIN (col jsonb_ops)',
+            new Index('index_name', ['col'], false, false, ['gin_jsonb']),
+            'table_name',
+        ];
+
+        yield 'Check multicolumn gin_jsonb flag' => [
+            'CREATE INDEX index_name ON table_name USING GIN (col1 jsonb_ops, col2 jsonb_ops)',
+            new Index('index_name', ['col1', 'col2'], false, false, ['gin_jsonb']),
+            'table_name',
+        ];
+
         yield 'Check gin_jsonb_path flag' => [
             'CREATE INDEX index_name ON table_name USING GIN (col jsonb_path_ops)',
             new Index('index_name', ['col'], false, false, ['gin_jsonb_path']),


### PR DESCRIPTION
Add ability to generate queries for GIN jsonb_ops index, by flag as it done for GIN jsonb_path_ops indexes

Solution will work until doctrine/dbal:4.0 where parent class `PostgreSQL100Platform` will be merged into `PostgreSQLPlatform` without `getIndexFieldDeclarationListSQL()` method which now deprecated (see https://github.com/doctrine/dbal/pull/5527)