### PR TITLE
Bump to doctrine dbal:^4.0 and orm:^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "phpspec/prophecy-phpunit": "^2.0",
     "symfony/cache": "^4.4 || ^5.4 || ^6.0",
     "lctrs/psalm-psr-container-plugin": "^1.6",
-    "psalm/plugin-phpunit": "^0.16.1",
-    "vimeo/psalm": "^4.22",
+    "psalm/plugin-phpunit": "^0.18",
+    "vimeo/psalm": "^5.0",
     "weirdan/doctrine-psalm-plugin": "^2.0"
   },
   "autoload": {
@@ -41,6 +41,7 @@
     }
   },
   "scripts": {
+    "psalm": "psalm",
     "test": "phpunit",
     "cs-check": "phpcs",
     "cs-fix": "phpcbf"

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0",
-    "doctrine/dbal": "^3.2",
-    "doctrine/orm": "^2.10"
+    "php": "^8.1",
+    "doctrine/dbal": "^4.0",
+    "doctrine/orm": "^3.0"
   },
   "require-dev": {
+    "ext-pdo_sqlite": "*",
     "phpunit/phpunit": "^9.5",
     "opsway/psr12-strict-coding-standard": "^0.7.0",
     "phpspec/prophecy-phpunit": "^2.0",
     "symfony/cache": "^4.4 || ^5.4 || ^6.0",
-    "doctrine/annotations": "^1.13",
     "lctrs/psalm-psr-container-plugin": "^1.6",
     "psalm/plugin-phpunit": "^0.16.1",
     "vimeo/psalm": "^4.22",
@@ -41,6 +41,7 @@
     }
   },
   "scripts": {
+    "test": "phpunit",
     "cs-check": "phpcs",
     "cs-fix": "phpcbf"
   }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require-dev": {
     "ext-pdo_sqlite": "*",
     "phpunit/phpunit": "^9.5",
-    "opsway/psr12-strict-coding-standard": "^0.7.0",
+    "opsway/psr12-strict-coding-standard": "^1.1",
     "phpspec/prophecy-phpunit": "^2.0",
     "symfony/cache": "^4.4 || ^5.4 || ^6.0",
     "lctrs/psalm-psr-container-plugin": "^1.6",

--- a/src/Doctrine/ORM/Query/AST/Functions/All.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/All.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class All extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Any.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Any.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class Any extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Arr.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Arr.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class Arr extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ArrayAggregate.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ArrayAggregate.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class ArrayAggregate extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ArrayAppend.php
@@ -7,9 +7,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\InputParameter;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -25,12 +25,12 @@ class ArrayAppend extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->InputParameter();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ArrayContains.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ArrayContains.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class ArrayContains extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ArrayRemove.php
@@ -7,9 +7,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\InputParameter;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -25,12 +25,12 @@ class ArrayRemove extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->InputParameter();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ArrayReplace.php
@@ -7,9 +7,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\InputParameter;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -30,14 +30,14 @@ class ArrayReplace extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->InputParameter();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr3 = $parser->InputParameter();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Cast.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Cast.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -23,15 +23,15 @@ class Cast extends FunctionNode
     private $expr2;
 
     /** @psalm-suppress all */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_AS);
-        $parser->match(Lexer::T_IDENTIFIER);
-        $this->expr2 = $parser->getLexer()->token['value'];
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_AS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $this->expr2 = $parser->getLexer()->token->value;
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Contained.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Contained.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class Contained extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Contains.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Contains.php
@@ -7,9 +7,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\InputParameter;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -25,12 +25,12 @@ class Contains extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->InputParameter();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Extract.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Extract.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,17 +24,17 @@ class Extract extends FunctionNode
     /** @psalm-suppress all */
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
-        $parser->match(Lexer::T_IDENTIFIER);
-        $this->field = $parser->getLexer()->token['value'];
+        $parser->match(TokenType::T_IDENTIFIER);
+        $this->field = $parser->getLexer()->token->value;
 
-        $parser->match(Lexer::T_FROM);
+        $parser->match(TokenType::T_FROM);
 
         $this->value = $parser->ScalarExpression();
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/GetJsonField.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/GetJsonField.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class GetJsonField extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/GetJsonFieldByKey.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/GetJsonFieldByKey.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class GetJsonFieldByKey extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/GetJsonObject.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/GetJsonObject.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class GetJsonObject extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/GetJsonObjectText.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/GetJsonObjectText.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class GetJsonObjectText extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/JsonAgg.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/JsonAgg.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class JsonAgg extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/JsonArrayLength.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/JsonArrayLength.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class JsonArrayLength extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsText.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/JsonbArrayElementsText.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class JsonbArrayElementsText extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/JsonbExists.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/JsonbExists.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -22,14 +22,14 @@ class JsonbExists extends FunctionNode
     /** @psalm-suppress all */
     private $expr2;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/RegexpReplace.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/RegexpReplace.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function implode;
 use function sprintf;
@@ -34,21 +34,21 @@ class RegexpReplace extends FunctionNode
     /** @psalm-suppress all */
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->text = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->pattern = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->replacement = $parser->StringPrimary();
         $this->flags       = null;
 
-        if (Lexer::T_COMMA === $parser->getLexer()->lookahead['type']) {
-            $parser->match(Lexer::T_COMMA);
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->flags = $parser->StringPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ToChar.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ToChar.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class ToChar extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->dateExpression = $parser->ArithmeticExpression();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->patternExpression = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ToTsquery.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ToTsquery.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,17 +24,17 @@ class ToTsquery extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
 
-        if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->config = $this->expr1;
             $this->expr1  = $parser->StringPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/ToTsvector.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/ToTsvector.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,17 +24,17 @@ class ToTsvector extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringExpression(); //SingleValuedPathExpression();
 
-        if ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->config = $this->expr1;
             $this->expr1  = $parser->StringExpression();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/TsConcat.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/TsConcat.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function array_map;
 use function implode;
@@ -21,18 +21,18 @@ class TsConcat extends FunctionNode
     public function parse(Parser $parser) : void
     {
         $lexer = $parser->getLexer();
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr[] = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr[] = $parser->StringPrimary();
 
-        while (Lexer::T_COMMA === $lexer->lookahead['type']) {
-            $parser->match(Lexer::T_COMMA);
+        while ($lexer->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->expr[] = $parser->StringPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/TsMatch.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/TsMatch.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -24,12 +24,12 @@ class TsMatch extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->StringPrimary();
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
         $this->expr2 = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/src/Doctrine/ORM/Query/AST/Functions/Unnest.php
+++ b/src/Doctrine/ORM/Query/AST/Functions/Unnest.php
@@ -6,9 +6,9 @@ namespace OpsWay\Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 use function sprintf;
 
@@ -20,10 +20,10 @@ class Unnest extends FunctionNode
 
     public function parse(Parser $parser) : void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
         $this->expr1 = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     /** @psalm-suppress all */

--- a/tests/EmTestCase.php
+++ b/tests/EmTestCase.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\TestCase;
 
 class EmTestCase extends TestCase
@@ -20,13 +21,16 @@ class EmTestCase extends TestCase
 
     protected function setUp() : void
     {
-        $config     = Setup::createConfiguration(true);
-        $driverImpl = $config->newDefaultAnnotationDriver([__DIR__]);
-        $config->setMetadataDriverImpl($driverImpl);
-        $this->em = EntityManager::create([
+        $config     = ORMSetup::createAttributeMetadataConfiguration([__DIR__], isDevMode: true);
+        $connection = DriverManager::getConnection([
             'driver' => 'pdo_sqlite',
             'memory' => true,
         ], $config);
+
+        $this->em = new EntityManager(
+            $connection,
+            $config,
+        );
 
         foreach ($this->customStringFunctions() as $name => $className) {
             $this->em->getConfiguration()->addCustomStringFunction($name, $className);

--- a/tests/Entity.php
+++ b/tests/Entity.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Id;
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping;
 
-/** @Entity */
+#[Mapping\Entity]
 class Entity
 {
-    /** @Id @Column(type="string") @GeneratedValue */
-    private $id;
+    #[Mapping\Id]
+    #[Mapping\Column]
+    #[Mapping\GeneratedValue]
+    private string $id;
 
-    /**
-     * @var array
-     * @Column(type="json", nullable=true, options={"jsonb": true})
-     */
-    private $metaData;
+    #[Mapping\Column(type: 'json', nullable: false, options: ['jsonb' => true])]
+    private array $metaData;
+
+    #[Mapping\Column(type: 'integer[]', nullable: false)]
+    private array $intArray;
+
+    #[Mapping\Column]
+    private string $stringValue;
+
+    #[Mapping\Column]
+    private DateTimeImmutable $updatedAt;
 }

--- a/tests/Unit/ORM/Query/AST/Functions/AllTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/AllTest.php
@@ -4,40 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\All;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class AllTest extends TestCase
+class AllTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var All  */
-    private $allFunction;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->allFunction = new All('test');
+        return [
+            'ALL_OP' => All::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->ArithmeticPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->allFunction->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('ALL(test)', $this->allFunction->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT e.id FROM OpsWay\Tests\Entity e WHERE 10000 = ALL_OP(e.intArray)',
+                'SELECT e0_.id AS id_0 FROM Entity e0_ WHERE 10000 = ALL(e0_.intArray)',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ArrayAppendTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ArrayAppendTest.php
@@ -4,45 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ArrayAppend;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ArrayAppendTest extends TestCase
+class ArrayAppendTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ArrayAppend */
-    private $arrayAppend;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->arrayAppend = new ArrayAppend('test');
+        return [
+            'ARR_APPEND' => ArrayAppend::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->InputParameter()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->arrayAppend->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $sqlWalker->walkInputParameter()->shouldBeCalled()->withArguments([$expr->reveal()])->willReturn('test');
-        $this->assertEquals(
-            'array_append(test, test)',
-            $this->arrayAppend->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT ARR_APPEND(e.intArray, :newItem) FROM OpsWay\Tests\Entity e',
+                'SELECT array_append(e0_.intArray, ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ArrayContainsTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ArrayContainsTest.php
@@ -4,44 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ArrayContains;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ArrayContainsTest extends TestCase
+class ArrayContainsTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ArrayContains */
-    private $arrayContains;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->arrayContains = new ArrayContains('test');
+        return [
+            'ARR_CONTAINS' => ArrayContains::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->arrayContains->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test && test)',
-            $this->arrayContains->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT ARR_CONTAINS(e.intArray, :search) FROM OpsWay\Tests\Entity e',
+                'SELECT (e0_.intArray && ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ArrayRemoveTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ArrayRemoveTest.php
@@ -4,45 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ArrayRemove;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ArrayRemoveTest extends TestCase
+class ArrayRemoveTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ArrayRemove */
-    private $arrayRemove;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->arrayRemove = new ArrayRemove('test');
+        return [
+            'ARR_REMOVE' => ArrayRemove::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->InputParameter()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->arrayRemove->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $sqlWalker->walkInputParameter()->shouldBeCalled()->withArguments([$expr->reveal()])->willReturn('test');
-        $this->assertEquals(
-            'array_remove(test, test)',
-            $this->arrayRemove->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT ARR_REMOVE(e.intArray, :oldValue) FROM OpsWay\Tests\Entity e',
+                'SELECT array_remove(e0_.intArray, ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ArrayReplaceTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ArrayReplaceTest.php
@@ -4,45 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ArrayReplace;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ArrayReplaceTest extends TestCase
+class ArrayReplaceTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ArrayReplace */
-    private $arrayReplace;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->arrayReplace = new ArrayReplace('test');
+        return [
+            'ARR_REPLACE' => ArrayReplace::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->InputParameter()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->arrayReplace->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $sqlWalker->walkInputParameter()->shouldBeCalled()->withArguments([$expr->reveal()])->willReturn('test');
-        $this->assertEquals(
-            'array_replace(test, test, test)',
-            $this->arrayReplace->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT ARR_REPLACE(e.intArray, :search, :replacement) FROM OpsWay\Tests\Entity e',
+                'SELECT array_replace(e0_.intArray, ?, ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ContainedTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ContainedTest.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\Contained;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ContainedTest extends TestCase
+class ContainedTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var Contained */
-    private $contained;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->contained = new Contained('test');
+        return [
+            'CONTAINED' => Contained::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->contained->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test <@ test)',
-            $this->contained->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT CONTAINED(e.metaData, :search) FROM OpsWay\Tests\Entity e',
+                'SELECT (e0_.metaData <@ ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ContainsTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ContainsTest.php
@@ -4,45 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\Contains;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ContainsTest extends TestCase
+class ContainsTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var Contains */
-    private $contains;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->contains = new Contains('test');
+        return [
+            'CONTAINS' => Contains::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->InputParameter()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->contains->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $sqlWalker->walkInputParameter()->shouldBeCalled()->withArguments([$expr->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test @> test)',
-            $this->contains->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT CONTAINS(e.metaData, :search) FROM OpsWay\Tests\Entity e',
+                'SELECT (e0_.metaData @> ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/GetJsonFieldByKeyTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/GetJsonFieldByKeyTest.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\GetJsonFieldByKey;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class GetJsonFieldByKeyTest extends TestCase
+class GetJsonFieldByKeyTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var GetJsonFieldByKey */
-    private $getJsonFieldByKey;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->getJsonFieldByKey = new GetJsonFieldByKey('test');
+        return [
+            'GET_JSON_FIELD_BY_KEY' => GetJsonFieldByKey::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->getJsonFieldByKey->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test->test)',
-            $this->getJsonFieldByKey->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                "SELECT GET_JSON_FIELD_BY_KEY(e.metaData, 'fieldName') FROM OpsWay\Tests\Entity e",
+                "SELECT (e0_.metaData->'fieldName') AS sclr_0 FROM Entity e0_",
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/GetJsonFieldTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/GetJsonFieldTest.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\GetJsonField;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class GetJsonFieldTest extends TestCase
+class GetJsonFieldTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var GetJsonField */
-    private $getJsonField;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->getJsonField = new GetJsonField('test');
+        return [
+            'GET_JSON_FIELD' => GetJsonField::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->getJsonField->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test->>test)',
-            $this->getJsonField->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                "SELECT GET_JSON_FIELD(e.metaData, 'fieldName') FROM OpsWay\Tests\Entity e",
+                "SELECT (e0_.metaData->>'fieldName') AS sclr_0 FROM Entity e0_",
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/GetJsonObjectTextTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/GetJsonObjectTextTest.php
@@ -4,43 +4,37 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\GetJsonObjectText;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class GetJsonObjectTextTest extends TestCase
+class GetJsonObjectTextTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var GetJsonObjectText */
-    private $getJsonObjectText;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->getJsonObjectText = new GetJsonObjectText('test');
+        return [
+            'GET_JSON_OBJECT_TEXT' => GetJsonObjectText::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->getJsonObjectText->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $this->assertEquals(
-            '(test #>> test)',
-            $this->getJsonObjectText->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                <<<'DQL'
+                SELECT GET_JSON_OBJECT_TEXT(e.metaData, '{fieldOnLevel1, fieldOnLevel2, fieldOnLevel3}')
+                FROM OpsWay\Tests\Entity e
+                DQL,
+                <<<'EXPECTED_SQL'
+                SELECT (e0_.metaData #>> '{fieldOnLevel1, fieldOnLevel2, fieldOnLevel3}') AS sclr_0 FROM Entity e0_
+                EXPECTED_SQL,
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/JsonAggTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/JsonAggTest.php
@@ -4,40 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\JsonAgg;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class JsonAggTest extends TestCase
+class JsonAggTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var JsonAgg */
-    private $jsonAgg;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->jsonAgg = new JsonAgg('test');
+        return [
+            'JSON_AGG' => JsonAgg::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->ArithmeticPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->jsonAgg->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('JSON_AGG(test)', $this->jsonAgg->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT JSON_AGG(e.metaData) FROM OpsWay\Tests\Entity e',
+                'SELECT JSON_AGG(e0_.metaData) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/JsonbArrayElementsTextTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/JsonbArrayElementsTextTest.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\JsonbArrayElementsText;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class JsonbArrayElementsTextTest extends TestCase
+class JsonbArrayElementsTextTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var JsonbArrayElementsText */
-    private $jsonbArrayElementsText;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->jsonbArrayElementsText = new JsonbArrayElementsText('test');
+        return [
+            'JSONB_ARRAY_ELEM_TEXT' => JsonbArrayElementsText::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->ArithmeticPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->jsonbArrayElementsText->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals(
-            'jsonb_array_elements_text(test)',
-            $this->jsonbArrayElementsText->getSql($sqlWalker->reveal())
-        );
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT JSONB_ARRAY_ELEM_TEXT(e.metaData) FROM OpsWay\Tests\Entity e',
+                'SELECT jsonb_array_elements_text(e0_.metaData) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/JsonbExistsTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/JsonbExistsTest.php
@@ -4,42 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\JsonbExists;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class JsonbExistsTest extends TestCase
+class JsonbExistsTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var JsonbExists */
-    private $jsonbExists;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->jsonbExists = new JsonbExists('test');
+        return [
+            'JSONB_EXISTS' => JsonbExists::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser    = $this->prophesize(Parser::class);
-        $expr      = $this->prophesize(ParenthesisExpression::class);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $this->jsonbExists->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('jsonb_exists(test, test)', $this->jsonbExists->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT JSONB_EXISTS(e.metaData, :fieldName) FROM OpsWay\Tests\Entity e',
+                'SELECT jsonb_exists(e0_.metaData, ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ToCharTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ToCharTest.php
@@ -4,43 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ToChar;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ToCharTest extends TestCase
+class ToCharTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ToChar */
-    private $toChar;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->toChar = new ToChar('test');
+        return [
+            'TO_CHAR' => ToChar::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser    = $this->prophesize(Parser::class);
-        $expr      = $this->prophesize(ParenthesisExpression::class);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->ArithmeticExpression()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-
-        $this->toChar->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('TO_CHAR(test, test)', $this->toChar->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                "SELECT TO_CHAR(e.metaData, 'YYYY-MM-DD HH24:MI:SS') FROM OpsWay\Tests\Entity e",
+                "SELECT TO_CHAR(e0_.metaData, 'YYYY-MM-DD HH24:MI:SS') AS sclr_0 FROM Entity e0_",
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/ToTsvectorTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/ToTsvectorTest.php
@@ -4,72 +4,36 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\ToTsvector;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class ToTsvectorTest extends TestCase
+class ToTsvectorTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var ToTsvector */
-    private $toTsvector;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->toTsvector = new ToTsvector('test');
+        return [
+            'TO_TSVECTOR' => ToTsvector::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
-        $lexer  = $this->prophesize(Lexer::class);
-
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringExpression()->shouldBeCalled()->willReturn($expr->reveal());
-
-        $parser->getLexer()->shouldBeCalled()->willReturn($lexer);
-        $lexer->isNextToken()->shouldBeCalled()->withArguments([Lexer::T_COMMA])->willReturn(false);
-
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->toTsvector->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('to_tsvector(test)', $this->toTsvector->getSql($sqlWalker->reveal()));
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
     }
 
-    public function testFunctionWithOptionalConfig() : void
+    public function functionData() : array
     {
-        $parser    = $this->prophesize(Parser::class);
-        $config    = $this->prophesize(ParenthesisExpression::class);
-        $expr      = $this->prophesize(ParenthesisExpression::class);
-        $lexer     = $this->prophesize(Lexer::class);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $config->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn("'english'");
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringExpression()->shouldBeCalled()->willReturn($config->reveal(), $expr->reveal());
-
-        $parser->getLexer()->shouldBeCalled()->willReturn($lexer);
-        $lexer->isNextToken()->shouldBeCalled()->withArguments([Lexer::T_COMMA])->willReturn(true);
-
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-
-        $this->toTsvector->parse($parser->reveal());
-
-        $this->assertEquals("to_tsvector('english', test)", $this->toTsvector->getSql($sqlWalker->reveal()));
+        return [
+            [
+                'SELECT TO_TSVECTOR(:param) FROM OpsWay\Tests\Entity e',
+                'SELECT to_tsvector(?) AS sclr_0 FROM Entity e0_',
+            ],
+            [
+                "SELECT TO_TSVECTOR('english', :param) FROM OpsWay\Tests\Entity e",
+                "SELECT to_tsvector('english', ?) AS sclr_0 FROM Entity e0_",
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/TsMatchTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/TsMatchTest.php
@@ -4,41 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\TsMatch;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class TsMatchTest extends TestCase
+class TsMatchTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var TsMatch */
-    private $tsMatch;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->tsMatch = new TsMatch('test');
+        return [
+            'TS_MATCH_OP' => TsMatch::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->StringPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_COMMA]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->tsMatch->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('(test @@ test)', $this->tsMatch->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT TS_MATCH_OP(e.stringValue, :param) FROM OpsWay\Tests\Entity e',
+                'SELECT (e0_.stringValue @@ ?) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/ORM/Query/AST/Functions/UnnestTest.php
+++ b/tests/Unit/ORM/Query/AST/Functions/UnnestTest.php
@@ -4,40 +4,32 @@ declare(strict_types=1);
 
 namespace OpsWay\Tests\Unit\ORM\Query\AST\Functions;
 
-use Doctrine\ORM\Query\AST\ParenthesisExpression;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
 use OpsWay\Doctrine\ORM\Query\AST\Functions\Unnest;
-use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use OpsWay\Tests\EmTestCase;
 
-class UnnestTest extends TestCase
+class UnnestTest extends EmTestCase
 {
-    use ProphecyTrait;
-
-    /** @var Unnest */
-    private $unnest;
-
-    public function setUp() : void
+    protected function customStringFunctions() : array
     {
-        $this->unnest = new Unnest('test');
+        return [
+            'UNNEST' => Unnest::class,
+        ];
     }
 
-    public function testFunction() : void
+    /** @dataProvider functionData */
+    public function testFunction(string $dql, string $sql) : void
     {
-        $parser = $this->prophesize(Parser::class);
-        $expr   = $this->prophesize(ParenthesisExpression::class);
+        $query = $this->em->createQuery($dql);
+        $this->assertEquals($sql, $query->getSql());
+    }
 
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_IDENTIFIER]);
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_OPEN_PARENTHESIS]);
-        $parser->ArithmeticPrimary()->shouldBeCalled()->willReturn($expr->reveal());
-        $parser->match()->shouldBeCalled()->withArguments([Lexer::T_CLOSE_PARENTHESIS]);
-        $sqlWalker = $this->prophesize(SqlWalker::class);
-
-        $this->unnest->parse($parser->reveal());
-        $expr->dispatch()->shouldBeCalled()->withArguments([$sqlWalker->reveal()])->willReturn('test');
-
-        $this->assertEquals('UNNEST(test)', $this->unnest->getSql($sqlWalker->reveal()));
+    public function functionData() : array
+    {
+        return [
+            [
+                'SELECT UNNEST(e.metaData) FROM OpsWay\Tests\Entity e',
+                'SELECT UNNEST(e0_.metaData) AS sclr_0 FROM Entity e0_',
+            ],
+        ];
     }
 }

--- a/tests/Unit/PostgreSQLPlatformDecoratorTest.php
+++ b/tests/Unit/PostgreSQLPlatformDecoratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpsWay\Tests\Unit;
 
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Table;
 use OpsWay\Doctrine\PostgreSQLPlatformDecorator;
 use PHPUnit\Framework\TestCase;
 
@@ -23,12 +22,11 @@ class PostgreSQLPlatformDecoratorTest extends TestCase
 
     /**
      * @dataProvider getCreateIndexSQLData
-     * @param string|Table $table
      */
     public function testGetCreateIndexSQL(
         string $expected,
         Index $index,
-        $table
+        string $table,
     ) : void {
         $actual = $this->platform->getCreateIndexSQL($index, $table);
 
@@ -47,12 +45,6 @@ class PostgreSQLPlatformDecoratorTest extends TestCase
             'CREATE INDEX index_name ON table_name (col1, col2)',
             new Index('index_name', ['col1', 'col2']),
             'table_name',
-        ];
-
-        yield 'Check without flags with Table instance' => [
-            'CREATE INDEX index_name ON table_name (col)',
-            new Index('index_name', ['col']),
-            new Table('table_name'),
         ];
 
         yield 'Check gist_intbig flag' => [


### PR DESCRIPTION
1. Update custom DQL functions to work with TokenType enum and Token object (instead array) in lookahead while parse query, because doctrine/orm package [drop support doctrine/lexer:^1.0](https://github.com/doctrine/orm/pull/10309)
1. Change parent of `PostgreSQLPlatformDecorator` because it (`PostgreSQL100Platform`) merged into [its parent](https://github.com/doctrine/dbal/pull/5069)(`PostgreSQLPlatform`) after drop support postgresql 9.
1. `PostgreSQLPlatform::getIndexFieldDeclarationListSQL()` [inlined](https://github.com/doctrine/dbal/pull/5532) so its implementation become protected (+ switch to match operator available in php 8.0) to be used in `PostgreSQLPlatformDecorator::getCreateIndexSQL()` which should add GIN|GiST index operators. Method also was inlined into:
      - `AbstractPlatform::getCreatePrimaryKeySQL()` - used only in previous method - getCreateIndexSQL() - but we cant change type of PRIMARY KEY index so no need to override it
      - `AbstractPlatform::getIndexDeclarationSQL()` - used only in AbstractPlatform::_getCreateTableSQL() implementation which overridden in parent class - PostgreSQLPlatform::_getCreateTableSQL(), so no need to override
    But first one only for primary keys which cant be GIN|GiST, and second one used in `CREATE TABLE` statement in general implementation - `AbstractPlatform::_getCreateTableSQL()` - which overridden in parent class `PostgreSQLPlatform` with updated `getCreateIndexSQL()` method call instead.
1. DQL `Parser` become `final` class while [migrate to php8](https://github.com/doctrine/orm/pull/10506/files#diff-87d60e195a7232304ce2247c699d530528bfd6249a1e7bc8913a23ecda68406bL48), so all unit-test share `TsConcatTest` approach to check SQL generation by DQL because it cant be mocked by Prophecy (package "phpspec/prophecy-phpunit" still used in `OpsWay\Tests\Unit\DBAL\Types` namespace).
1.  Fix `EntityManager` construction in `EmTestCase` because deprecation of public constructor and annotations driver
1. Case 'Check without flags with Table instance' in `PostgreSQLPlatformDecoratorTest` removed because not we have type-hinting where table always string
1. Add `ext-pdo_sqlite` to dev requirements because DQL function test may call dbal `Connection::quote()` method 
1. Left `EmTestCase` create manager with `isDevMode` configuration to use symfony `ArrayAdapter` cache instead of any localhost redis on default port (it may be error-prone when change Entity fields mapping)
1. Bump `opsway/psr12-strict-coding-standard` to current version because it fixed after its dependency (slevomat rules) change some rule parameters