### PR TITLE
Fix return type for getSQLDeclaration

### DIFF
--- a/src/Doctrine/DBAL/Types/Inet.php
+++ b/src/Doctrine/DBAL/Types/Inet.php
@@ -20,7 +20,7 @@ class Inet extends Type
 
     public function getSQLDeclaration(array $column, AbstractPlatform $platform) : string
     {
-        return $platform->getDoctrineTypeMapping(Types::INET);
+        return Types::INET;
     }
 
     /**


### PR DESCRIPTION
Fix return type error. The `getSQLDeclaration` method must return string with `inet` value.
bin/console doctrine:schema:update --force
In ExceptionConverter.php line 87:
                                                                                                                           
  An exception occurred while executing a query: SQLSTATE[42704]: Undefined object: 7 ERROR:  type "string" does not exist  
  LINE 1: CREATE TABLE xxx (ip **string** NOT NULL, ...